### PR TITLE
Add a handler to do something in the event that the TcpClient's run() throws an exception

### DIFF
--- a/app/src/main/java/jimpatrizi/com/netrtl/MainActivity.java
+++ b/app/src/main/java/jimpatrizi/com/netrtl/MainActivity.java
@@ -734,6 +734,7 @@ public class MainActivity extends AppCompatActivity
             tcpClient = new TcpClient(ipAddress, portNumber);
             //Init tcpClient thread
             tcpClientThread = new Thread(tcpClient, TcpClient.getDefaultThreadName());
+            tcpClientThread.setUncaughtExceptionHandler(getTcpClientExceptionHandler());
             //Start tcpClient in new thread, starts in run() because implements runnable
             tcpClientThread.start();
             //init response listener
@@ -1065,5 +1066,24 @@ public class MainActivity extends AppCompatActivity
         offsetSwitch = (Switch) findViewById(R.id.offset);
         offsetSwitch.setOnCheckedChangeListener(new SwitchOnCheckedChangeListener(OFFSET));
         enableOptionUiMatcher.add(OFFSET, offsetSwitch);
+    }
+
+    /**
+     * @return A function to handle when an uncaught exception is thrown from a
+     *         TcpClient or its inner threads.
+     */
+    private static Thread.UncaughtExceptionHandler getTcpClientExceptionHandler()
+    {
+        final Thread.UncaughtExceptionHandler uncaughtExceptionHandler = new Thread.UncaughtExceptionHandler()
+        {
+            @Override
+            public void uncaughtException(final Thread thread, final Throwable exception)
+            {
+                MainActivity.showGotItDialog("TcpClient exception!",
+                        "Make sure you have the proper IP set!\nException: " + exception.toString(),
+                        true);
+            }
+        };
+        return uncaughtExceptionHandler;
     }
 }

--- a/app/src/main/java/jimpatrizi/com/netrtl/Parameters.java
+++ b/app/src/main/java/jimpatrizi/com/netrtl/Parameters.java
@@ -88,7 +88,7 @@ public enum Parameters {
         for (String s:values) {
             if(val.equals(s))
             {
-//                showGotItDialog("Parameter Warning!" , "Attempting to set" + this.FUNCTION + "with: " + val + "more than once", false);
+            //showGotItDialog("Parameter Warning!" , "Attempting to set" + this.FUNCTION + "with: " + val + "more than once", false);
                 return;
             }
         }

--- a/app/src/main/java/jimpatrizi/com/netrtl/Parameters.java
+++ b/app/src/main/java/jimpatrizi/com/netrtl/Parameters.java
@@ -88,7 +88,7 @@ public enum Parameters {
         for (String s:values) {
             if(val.equals(s))
             {
-            //showGotItDialog("Parameter Warning!" , "Attempting to set" + this.FUNCTION + "with: " + val + "more than once", false);
+                //showGotItDialog("Parameter Warning!" , "Attempting to set" + this.FUNCTION + "with: " + val + "more than once", false);
                 return;
             }
         }

--- a/app/src/main/java/jimpatrizi/com/netrtl/Parameters.java
+++ b/app/src/main/java/jimpatrizi/com/netrtl/Parameters.java
@@ -88,7 +88,7 @@ public enum Parameters {
         for (String s:values) {
             if(val.equals(s))
             {
-                //showGotItDialog("Parameter Warning!" , "Attempting to set" + this.FUNCTION + "with: " + val + "more than once", false);
+//                showGotItDialog("Parameter Warning!" , "Attempting to set" + this.FUNCTION + "with: " + val + "more than once", false);
                 return;
             }
         }


### PR DESCRIPTION
This specifically, this handles the case where you've entered the wrong IP and attempt
to connect to a server that doesn't exist.

This requires that your rtlsdrdJavaInterfaces repo is updated to include the
d5106c6 commit. Also, you need to change TcpClient.run() to have the first lines:
```java
	try
	{
	initMembers();
        }
        // Hacky way to get around our inability to throw an exception from run()
        catch (IOException exception)
        {
            logMsg("IOException caught when initializing members of TcpClient. Error: " + exception.toString());
            throw new RuntimeException(exception);
        }
```